### PR TITLE
RDS support

### DIFF
--- a/modules/infra/outputs.tf
+++ b/modules/infra/outputs.tf
@@ -60,3 +60,8 @@ output "cluster_token" {
 output "persistence_ids" {
   value = "${aws_ebs_volume.persistence[*].id}"
 }
+
+output "this_db_instance_endpoint" {
+  description = "The RDS DB connection endpoint"
+  value       = "${module.db.this_db_instance_endpoint}"
+}

--- a/modules/infra/rds.tf
+++ b/modules/infra/rds.tf
@@ -1,0 +1,52 @@
+#####
+# DB
+#####
+module "db" {
+  source  = "terraform-aws-modules/rds/aws"
+  identifier = "${var.cluster_name}-rds-postgres"
+
+  engine            = "postgres"
+  engine_version    = "9.5"
+  instance_class    = "db.t2.large"
+  allocated_storage = 5
+  storage_encrypted = false
+
+  # kms_key_id        = "arm:aws:kms:<region>:<account id>:key/<kms key id>"
+  name = "dockup_ui_prod"
+
+  # NOTE: Do NOT use 'user' as the value for 'username' as it throws:
+  # "Error creating DB Instance: InvalidParameterValue: MasterUsername
+  # user cannot be used as it is a reserved word used by the engine"
+  username = var.pg_user
+
+  password = var.pg_password
+  port     = var.pg_port
+
+  vpc_security_group_ids = ["${aws_security_group.eks-cluster.id}"]
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+
+  # disable backups to create DB faster
+  backup_retention_period = 0
+
+  tags = {
+    Owner       = "user"
+    Environment = "prod"
+  }
+
+  # DB subnet group
+  subnet_ids = "${aws_subnet.eks-cluster[*].id}"
+
+  # DB parameter group
+  family = "postgres9.5"
+
+  # DB option group
+  major_engine_version = "9.5"
+
+  # Snapshot name upon DB deletion
+  final_snapshot_identifier = "${var.cluster_name}-rds-postgres-snapshot"
+
+  # Database Deletion Protection
+  deletion_protection = false
+}

--- a/modules/infra/variables.tf
+++ b/modules/infra/variables.tf
@@ -21,3 +21,19 @@ variable "persistence_ebs_volumes_size" {
   default = 1
   type = number
 }
+
+# Configure RDS
+variable "pg_user" {
+  default = "dockup_user"
+  type = string
+}
+
+variable "pg_password" {
+  default = "sup3rs3cr3tpAssw0rd"
+  type = string
+}
+
+variable "pg_port" {
+  default = 5432
+  type = number
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,8 @@ output "kubeconfig" {
 output "persistence_ids" {
   value = module.infra.persistence_ids
 }
+
+output "this_db_instance_endpoint" {
+  description = "The connection endpoint"
+  value       = "${module.infra.this_db_instance_endpoint}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,21 @@ variable "traefik_gandiv5_key" {
   default = "gandi-pai-key"
   type = string
 }
+
+
+# Configure RDS
+variable "pg_user" {
+  default = "dockup_user"
+  type = string
+}
+
+variable "pg_password" {
+  default = "sup3rs3cr3tpAssw0rd"
+  type = string
+}
+
+variable "pg_port" {
+  default = 5432
+  type = number
+}
+


### PR DESCRIPTION
* Have ran this couple of times in local terraform apply

* @iffyuva is it possible to disable creation of RDS if we chose not to. Is there a way i can do this?

I mean, this PR is introduced as we needed to an activity to spin up RDS for the infra, but its not always the use case of this repo.

There are some more variables that i feel can be configured:
* allocated storage
* engine ( for multiple db support 🤔 )
* instance class ( this could be complicated, so perhaps leave it hard coded? )